### PR TITLE
BAU: add --aws-vault flag for aws-vault users

### DIFF
--- a/request_ssh_access/__main__.py
+++ b/request_ssh_access/__main__.py
@@ -42,6 +42,7 @@ def main(args=None):
         generate_signed_cert(
             args.environment,
             args.user_name,
+            args.aws_vault,
             args.ttl,
             args.input_ssh_cert,
             get_output_cert_path(args),
@@ -54,6 +55,7 @@ def main(args=None):
 def generate_signed_cert(
     environment,
     username,
+    using_awsvault,
     ttl=60 * 60 * 4,
     input_ssh_cert=config.DEFAULT_PUBKEY_PATH,
     output_ssh_cert=config.DEFAULT_CERT_PATH,
@@ -68,7 +70,9 @@ def generate_signed_cert(
 
     environment = environment.lower().strip()
     if environment not in PRODUCTION_ENVS:
-        wrapped_token = invoke_grant_ssh_access(username, environment, ttl)
+        wrapped_token = invoke_grant_ssh_access(
+            username, environment, ttl, using_awsvault
+        )
     else:
         print_lambda_command_to_copy(username, environment, ttl)
 
@@ -141,9 +145,10 @@ def write_cert_to_file(output_ssh_cert, unwrapped_cert):
     print("signed certificate written to '{}'.".format(output_ssh_cert))
 
 
-def invoke_grant_ssh_access(username, environment, ttl):
+def invoke_grant_ssh_access(username, environment, ttl, using_awsvault):
 
-    boto3.setup_default_session(profile_name="webops-users")
+    if not using_awsvault:
+        boto3.setup_default_session(profile_name="webops-users")
 
     sts_connection = boto3.client("sts")
     account_id = sts_connection.get_caller_identity()["Account"]
@@ -232,6 +237,12 @@ def parse_args(argv):
         type=int,
         required=False,
         default=config.DEFAULT_TTL,
+    )
+
+    parser.add_argument(
+        "--aws-vault",
+        help="Flag to set if you are using aws-vault",
+        action="store_true",
     )
 
     args = parser.parse_args(argv)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,47 @@ def test_production_happy_path(
 
 
 @patch("request_ssh_access.__main__.boto3.client", autospec=True)
+def test_production_happy_path_for_vault_user(
+    mocked_boto3_client, tmp_path, monkeypatch, mocked_responses, capsys
+):
+    output_ssh_cert = str(tmp_path / "id_rsa-cert.pub")
+    input_ssh_cert = str(tmp_path / "id_rsa.pub")
+    args = (
+        "--user-name",
+        "myUserName",
+        "--environment",
+        "production",
+        "--input-ssh-cert",
+        input_ssh_cert,
+        "--output-ssh-cert",
+        output_ssh_cert,
+        "--aws-vault",
+    )
+
+    fake_get_input = Mock(return_value="s.wrapped_token")
+    monkeypatch.setattr(main, "get_input", fake_get_input)
+    monkeypatch.setattr(main.getpass, "getpass", Mock(return_value="000000"))
+
+    mocked_responses.add(
+        mocked_responses.POST,
+        url=re.compile(r".*auth/ldap/login.*"),
+        body=json.dumps({"auth": {"client_token": "vault-token"}}),
+    )
+
+    mocked_responses.add(
+        mocked_responses.POST,
+        url=re.compile(r".*sys/wrapping/unwrap"),
+        body=json.dumps({"data": {"signed_key": "signed_key"}}),
+    )
+
+    mocked_payload = Mock()
+    mocked_payload.read.return_value = '{"token": "s.atimakkok"}'
+    mocked_boto3_client.return_value.invoke.return_value = {"Payload": mocked_payload}
+
+    main.main(args)
+
+
+@patch("request_ssh_access.__main__.boto3.client", autospec=True)
 def test_happy_path(
     mocked_boto3_client, tmp_path, monkeypatch, mocked_responses, capsys
 ):


### PR DESCRIPTION
The webops-users aws profile should be selected by using aws-vault
before invoking request-ssh-access so boto will use the correct
profile

Setting the default session to use webops-users profile works
for users of aws-profile but breaks for users of aws-vault