### PR TITLE
INFRA-7724: Return the error when it occurs in non-production errors

### DIFF
--- a/request_ssh_access/__main__.py
+++ b/request_ssh_access/__main__.py
@@ -177,7 +177,13 @@ def invoke_grant_ssh_access(username, environment, ttl):
         Payload=json.dumps({"user_name": username, "ttl": ttl}),
     )
 
-    return json.loads(response["Payload"].read()).get("token")
+    payload = json.loads(response["Payload"].read())
+
+    token = payload.get("token")
+    if "error" in payload or token is None:
+        raise Exception(f"Invalid response from lambda: {payload}")
+
+    return token
 
 
 def yes_or_no(question):

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,8 @@ addopts = --cov-fail-under=90
 
 [flake8]
 max-complexity = 10
-exclude = .git,__pycache__,build,dist,.tox
-max-line-length = 88
+exclude = .git,__pycache__,build,dist,.tox,venv
+max-line-length = 100
 ignore=D103,D107,W503,D104
 
 [coverage:html]


### PR DESCRIPTION
In non-production environments the Lambda is invoked by the user running the request-ssh-access command.

We noticed the grant-ssh-access Lambda was failing but we weren't expecting an error.

This change checks the response from the Lambda for a token, or error, and responds accordingly.